### PR TITLE
ensure that multiple runs don't cause repeat entries

### DIFF
--- a/test/fixtures/clusterserviceversion-with-preexisting.yaml
+++ b/test/fixtures/clusterserviceversion-with-preexisting.yaml
@@ -118,36 +118,6 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                # test case with no tag at all, e.g. latest
-                image: quay.io/opdev/simple-demo-operator
-                livenessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 8081
-                  initialDelaySeconds: 15
-                  periodSeconds: 20
-                name: manager
-                readinessProbe:
-                  httpGet:
-                    path: /readyz
-                    port: 8081
-                  initialDelaySeconds: 5
-                  periodSeconds: 10
-                resources:
-                  limits:
-                    cpu: 200m
-                    memory: 100Mi
-                  requests:
-                    cpu: 100m
-                    memory: 20Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
-                - --leader-elect
-                command:
-                - /manager
                 # test case with a tag
                 image: quay.io/opdev/simple-demo-operator:0.0.3
                 livenessProbe:


### PR DESCRIPTION
Fixes #1 by adding all related images to a map, so duplicate RelatedImage.Name values are replaced.